### PR TITLE
WP-GeoMeta v0.4.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,35 +165,22 @@ orderby with named meta clauses should work. It's a new feature though, so send 
 Server Requirements
 -------------------
 
-### WordPress
-This plugin supports storing spatial metadata for posts, users, comments and
-terms. 
+### WordPress 
 
-Setting, getting and querying values should work in 4.1 with some missing functionality. 
-Running orderby doesn't work until 4.2
-Searching term metadata arrived in WordPress 4.4, but other
-functionality should still work in older versions of WordPress.
+Supports WordPress 6+
 
-MySQL 5.6.1 or higher is strongly recommended. Lower than MySQL 5.1.72 is untested.
+### MySQL
 
-WP_GeoMeta will probably work on MySQL 5.4, but spatial support was pretty weak 
-before version 5.6.1. 
-
-Before MySQL 5.6.1 spatial functions worked against the mininum bounding rectangle 
-instead of the actual geometry.
-
-MySQL 5.7 brough spatial indexes to InnoDB tables. Before that only MyISAM tables
-supported spatial indexes. Anything else required a full table scan. 
-
-If you are using MySQL 5.7, good for you, and consider converting your geo tables
-to InnoDB! (and let me know how it goes).
+Supports MySQL 5.7+
 
 ### PHP
-PHP 5.2.4 and higher are supported, just like WordPress's minimum version.
-Please report any PHP errors you come across and we'll fix them up.
+
+Supports PHP 7.4+
 
 Frequently Asked Questions
 --------------------------
+
+This [talk](https://luminfire.com/2017/08/28/spatially-enable-wordpress-wp-geometa-lib/) by [Michael Moore](https://github.com/stuporglue) and accompanying [slides](https://luminfire.com/wp-content/uploads/2017/08/Spatially_Enable_WordPress_With_WP-GeoMeta-Lib.pdf) give an excellent overview of the project.
 
 ### What spatial comparisons are supported?
 

--- a/joe.md
+++ b/joe.md
@@ -1,3 +1,0 @@
-WordPress has some security rules surrounding using wildcards in queries. From the [$wpdb->prepare docs](https://developer.wordpress.org/reference/classes/wpdb/prepare/):
-
-> Literal percentage signs (%) in the query string must be written as %%. Percentage wildcards (for example, to use in LIKE syntax) must be passed via a substitution argument containing the complete LIKE string, these cannot be inserted directly in the query string.

--- a/joe.md
+++ b/joe.md
@@ -1,0 +1,3 @@
+WordPress has some security rules surrounding using wildcards in queries. From the [$wpdb->prepare docs](https://developer.wordpress.org/reference/classes/wpdb/prepare/):
+
+> Literal percentage signs (%) in the query string must be written as %%. Percentage wildcards (for example, to use in LIKE syntax) must be passed via a substitution argument containing the complete LIKE string, these cannot be inserted directly in the query string.

--- a/lib/wp-geometa-dash.php
+++ b/lib/wp-geometa-dash.php
@@ -769,7 +769,7 @@ class WP_GeoMeta_Dash {
 			t.' . $table_id . ' AS the_id,
 			m.meta_key,
 			m.meta_value,
-			AsText(geo.meta_value) AS geo_meta_value,
+			ST_AsText(geo.meta_value) AS geo_meta_value,
 			geo.meta_key AS geo_meta_key
 			FROM 	
 			' . $wpdb->$metatype . ' m,

--- a/lib/wp-geometa-dash.php
+++ b/lib/wp-geometa-dash.php
@@ -535,13 +535,25 @@ class WP_GeoMeta_Dash {
 
 		$total_meta = 0;
 		$total_geo = 0;
-
+		
+		//We are comparing each meta table (wp_postmeta, wp_termmeta, wp_usermeta, wp_commentmeta)
+		//with it's _geo "partner" (wp_postmeta_geo, wp_termmeta_geo, wp_usermeta_geo, wp_commentmeta_geo)
 		foreach ( $wpgm->meta_types as $meta_type ) {
 			$metatable = _get_meta_table( $meta_type );
 			$geotable = $metatable . '_geo';
 
-			$num_meta = $wpdb->get_var( "SELECT COUNT(*) FROM $metatable WHERE $metatable.meta_value LIKE '%{%Feature%geometry%}%'" ); // @codingStandardsIgnoreLine
+			// Count rows containing GeoJSON in the WP meta table
+			// WordPress has some security rules surrounding using wildcards in queries.
+			// See https://developer.wordpress.org/reference/classes/wpdb/prepare/
+			$sql = $wpdb->prepare("
+				SELECT COUNT(*)
+				FROM {$metatable}
+				WHERE 
+					meta_value LIKE '%s'	
+			", '%{%Feature%geometry%}%');		
 
+			$num_meta = $wpdb->get_var( $sql );
+			
 			$total_meta += $num_meta;
 
 			if ( 0 === $num_meta ) {
@@ -550,7 +562,9 @@ class WP_GeoMeta_Dash {
 			}
 
 			if ( in_array( $meta_type, $this->table_types_found, true ) ) {
-				$num_geo = $wpdb->get_var( "SELECT COUNT(*) FROM $geotable" ); // @codingStandardsIgnoreLine
+				// Count rows in the _geo table
+				$sql = $wpdb->prepare("SELECT COUNT(*) FROM {$geotable}");
+				$num_geo = $wpdb->get_var( $sql );
 
 				$total_geo += $num_geo;
 			} else {
@@ -568,7 +582,9 @@ class WP_GeoMeta_Dash {
 		if ( 0 === $total_meta ) {
 			$total_percent = 100;
 		} else {
-			$total_percent = (int) ($total_geo / $total_meta * 100);
+			//A float prevents small percentages (between 0 and 1) being rounded off
+			//We round to 2 DP for presentation (i.e. 0.01%)
+			$total_percent = (float) round($total_geo / $total_meta * 100, 2);
 		}
 
 		if ( 100 === $total_percent ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === WP-GeoMeta ===
-Contributors: stuporglue, luminfire, andywalz
+Contributors: stuporglue, luminfire, andywalz, morehawes
 Donate link: https://LuminFire.com/contact-us/make-a-payment/
 Tags: GIS, geo, spatial, mysql, mariadb, geography, mapping, meta, metadata
-Requires at least: 4.4.0
-Tested up to: 4.9
+Requires PHP: 7.4
+Requires at least: 6.0
+Tested up to: 6.0
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -51,6 +52,11 @@ For fast and short questions you can [contact me](https://twitter.com/stuporglue
 5. GeoJSON Import Functionality
 
 == Changelog ==
+
+= 0.4.0 =
+ * Tests passing up to PHP 8 / WP 6 / MySQL 8.
+ * [WP-GeoMeta-Lib](https://github.com/BrilliantPlugins/wp-geometa-lib) updated to v0.4.0, addressing several [open issues](https://github.com/BrilliantPlugins/wp-geometa/issues)).
+ * Numerous fixes, mostly migrating now-removed MySQL spacial functions with their ST_ equivalents [more info](https://dev.mysql.com/doc/refman/5.7/en/spatial-relation-functions-object-shapes.html).
 
 = 0.3.6 =
  * Upgraded leaflet-php library.

--- a/wp-geometa.php
+++ b/wp-geometa.php
@@ -11,7 +11,7 @@
  * Description: Store and search spatial metadata while taking advantage of MySQL spatial types and indexes.
  * Author: Michael Moore
  * Author URI: http://LuminFire.com
- * Version: 0.3.5
+ * Version: 0.4.0
  * Text Domain: wp-geometa
  * Domain Path: /lang
  *


### PR DESCRIPTION
 * Tested up to PHP 8 / WP 6 / MySQL 8.
 * [WP-GeoMeta-Lib](https://github.com/BrilliantPlugins/wp-geometa-lib) updated to v0.4.0, (addressing several [open issues](https://github.com/BrilliantPlugins/wp-geometa/issues)).
 * Numerous fixes, mostly migrating now-removed MySQL spacial functions with their ST_ equivalents [more info](https://dev.mysql.com/doc/refman/5.7/en/spatial-relation-functions-object-shapes.html).
